### PR TITLE
fix: fetch delegate before delegate

### DIFF
--- a/src/evm/writers.ts
+++ b/src/evm/writers.ts
@@ -26,8 +26,8 @@ export default function createWriters(indexerName: NetworkID) {
     if (!event) return;
 
     const governanceId = source?.contract || '';
-    const governance = await getGovernance(indexerName, governanceId);
     const delegate = await getDelegate(indexerName, event.args.delegate, governanceId);
+    const governance = await getGovernance(indexerName, governanceId);
 
     delegate.delegatedVotesRaw = BigInt(event.args.newBalance).toString();
     delegate.delegatedVotes = formatUnits(event.args.newBalance, DECIMALS);


### PR DESCRIPTION
getDelegate can in some cases create new Governance. With previous order it would result in governance entity from getGovernance call that is treated as new entity so when we save it it will result in conflict (because it's existing entity as it was already created by getDelegate).

By changing this order we workaround this issue.

## Test plan

1. Run it with following patch.
2. It works (previously it would halt due to conflict).

```diff
diff --git a/src/evm/config.ts b/src/evm/config.ts
index 1eed14c..1d0547a 100644
--- a/src/evm/config.ts
+++ b/src/evm/config.ts
@@ -16,35 +16,10 @@ const NETWORK_NODE_URLS: Record<NetworkID, string> = {
 
 const TOKEN_SOURCES: Record<NetworkID, Source[]> = {
   eth: [
-    {
-      name: 'STRK',
-      contract: '0xca14007eff0db1f8135f4c25b34de49ab0d42766',
-      start: 15983290
-    },
-    {
-      name: 'NSTR',
-      contract: '0x610dbd98a28ebba525e9926b6aaf88f9159edbfd',
-      start: 19952803
-    },
     {
       name: 'UNI',
       contract: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
-      start: 10861674
-    },
-    {
-      name: 'ENS',
-      contract: '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72',
-      start: 13533418
-    },
-    {
-      name: 'SHU',
-      contract: '0xe485e2f1bab389c08721b291f6b59780fec83fd7',
-      start: 19021394
-    },
-    {
-      name: 'COMP',
-      contract: '0xc00e94cb662c3520282e6f5717214004a7f26888',
-      start: 9601359
+      start: 13728203
     }
   ],
   arb1: [
diff --git a/src/evm/index.ts b/src/evm/index.ts
index 64635e0..cc96884 100644
--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -7,5 +7,5 @@ const arb1Indexer = new evm.EvmIndexer(createWriters('arb1'));
 
 export function addEvmIndexers(checkpoint: Checkpoint) {
   checkpoint.addIndexer('eth', createConfig('eth'), ethIndexer);
-  checkpoint.addIndexer('arb1', createConfig('arb1'), arb1Indexer);
+  // checkpoint.addIndexer('arb1', createConfig('arb1'), arb1Indexer);
 }
diff --git a/src/index.ts b/src/index.ts
index bd22901..e4858aa 100644
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ async function run() {
   });
 
   addEvmIndexers(checkpoint);
-  addStarknetIndexers(checkpoint);
+  // addStarknetIndexers(checkpoint);
 
   const server = new ApolloServer({
     schema: checkpoint.getSchema(),
@@ -62,7 +62,7 @@ async function run() {
   await checkpoint.reset();
   console.log('Checkpoint ready');
 
-  // await checkpoint.start();
+  await checkpoint.start();
 }
 
 run();

```